### PR TITLE
Fixed deploy

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,0 +1,8 @@
+#Only Localhost config
+SSL_PORT=443
+PKEY = './cert_and_key/hacksparrow-key.pem'
+SSLCERT = './cert_and_key/hacksparrow-cert.pem'
+#localhost to get it up with SSL configuration on SSL_PORT
+ENVIRONMENT='localhost'
+#Config
+PORT=3000

--- a/README.md
+++ b/README.md
@@ -48,9 +48,12 @@ _Read move about environment configuration here: [dotenv](https://github.com/mot
    This `.env` file is ignored by the rules set in `.gitignore`, therefore in this file you may freely customizable the deployment to your own needs.
 
     ```
-    PORT=443
+    ##Only Localhost config
+    LOCAL_PORT=443
     PKEY="./cert_and_key/hacksparrow-key.pem"
     SSLCERT="./cert_and_key/hacksparrow-cert.pem"
+    #config for OpenShift deploy
+    PORT=3000
     ```
 
 
@@ -99,6 +102,24 @@ In development mode the [Nodemon](https://nodemon.io/) will automatically detect
 ```
 npm run dev
 ```
+
+### Run the site on localhost
+To run it on your local computer you have to add a (self signed) certificate and a private key and put those entries in to the .env file.
+
+ex.
+```
+#Only Localhost config
+LOCAL_PORT=443
+PKEY = './cert_and_key/hacksparrow-key.pem'
+SSLCERT = './cert_and_key/hacksparrow-cert.pem'
+#Config
+PORT=3000
+```
+Run with:
+```
+npm run local
+```
+
 
 ## Built with
 

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const portabilityApi = require('./lib/portability-api');
 const fs = require('fs');
 const https = require('https');
 const http = require('http');
-const whatHost = process.argv[2] || 'deploy';
+const whatHost = config.environment;
 let server;
 
 if(whatHost==='localhost' ){
@@ -66,7 +66,7 @@ app.get('/cv', (req, res) => {
 });
 
 if(whatHost==='localhost' ){
-    server.listen(config.localPort, 'demotest.arbetsformedlingen.se', () => console.log(`Gravity Demo Site listening on port ${config.localPort}!`) );
+    server.listen(config.sslPort, 'demotest.arbetsformedlingen.se', () => console.log(`Gravity Demo Site listening on port ${config.sslPort}!`) );
 }else{
     server.listen(config.port, 'demotest.arbetsformedlingen.se', () => console.log(`Gravity Demo Site listening on port ${config.port}!`) );
 }

--- a/index.js
+++ b/index.js
@@ -7,10 +7,18 @@ const jwtService = require('./lib/jwt-service');
 const portabilityApi = require('./lib/portability-api');
 const fs = require('fs');
 const https = require('https');
-const privateKey  = fs.readFileSync(config.pkey, 'utf8');
-const certificate = fs.readFileSync(config.sslcert, 'utf8');
-const credentials = {key: privateKey, cert: certificate};
+const http = require('http');
+const whatHost = process.argv[2] || 'deploy';
+let server;
 
+if(whatHost==='localhost' ){
+    const privateKey  = fs.readFileSync(config.pkey, 'utf8');
+    const certificate = fs.readFileSync(config.sslcert, 'utf8');
+    const credentials = {key: privateKey, cert: certificate};
+    server = https.createServer(credentials, app);
+} else{
+    server = http.createServer(app);
+}
 
 function getRequestCookie(req, name) {
     var value = '; ' + req.headers.cookie;
@@ -56,6 +64,9 @@ app.get('/cv', (req, res) => {
         res.sendStatus(500);
     });
 });
-const httpsServer = https.createServer(credentials, app);
-httpsServer.listen(config.port, 'demotest.arbetsformedlingen.se', () => console.log(`Gravity Demo Site listening on port ${config.port}!`) );
-//app.listen(config.port,'demotest.arbetsformedlingen.se', () => console.log(`Gravity Demo Site listening on port ${config.port}!`));
+
+if(whatHost==='localhost' ){
+    server.listen(config.localPort, 'demotest.arbetsformedlingen.se', () => console.log(`Gravity Demo Site listening on port ${config.localPort}!`) );
+}else{
+    server.listen(config.port, 'demotest.arbetsformedlingen.se', () => console.log(`Gravity Demo Site listening on port ${config.port}!`) );
+}

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -3,6 +3,7 @@ const dotenv = require('dotenv');
 dotenv.config();
 module.exports = {
   port: process.env.PORT || 3000,
+  localPort: process.env.LOCAL_PORT || 443,
   afLoginUrl: process.env.AF_LOGIN_URL || 'https://www.arbetsformedlingen.se/loggain',
   afJwtUrl: process.env.AF_JWT_URL || 'http://jwt.arbetsformedlingen.se/jwt/rest/idp/v0/klientID',
   afJwtHost: process.env.AF_JWT_HOST || 'jwt.arbetsformedlingen.se',

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -3,7 +3,7 @@ const dotenv = require('dotenv');
 dotenv.config();
 module.exports = {
   port: process.env.PORT || 3000,
-  localPort: process.env.LOCAL_PORT || 443,
+  sslPort: process.env.LOCAL_PORT || 443,
   afLoginUrl: process.env.AF_LOGIN_URL || 'https://www.arbetsformedlingen.se/loggain',
   afJwtUrl: process.env.AF_JWT_URL || 'http://jwt.arbetsformedlingen.se/jwt/rest/idp/v0/klientID',
   afJwtHost: process.env.AF_JWT_HOST || 'jwt.arbetsformedlingen.se',
@@ -11,6 +11,6 @@ module.exports = {
   portabilityHost: process.env.PORTABILITY_HOST || 'portability.stage.opservices.jtech.se',
   ssoCookieName: process.env.SSO_COOKIE_NAME || 'AMV_SSO_COOKIE',
   pkey: process.env.PKEY || './cert_and_key/wc.arbetsformedlingen.se.key',
-  sslcert: process.env.SSLCERT || './cert_and_key/wc.arbetsformedlingen.se.crt'
-
+  sslcert: process.env.SSLCERT || './cert_and_key/wc.arbetsformedlingen.se.crt',
+  environment:process.env.ENVIRONMENT || ''
 };

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "scripts": {
     "start": "node index.js",
+    "local": "node index.js localhost",
     "dev": "nodemon",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   },
   "scripts": {
     "start": "node index.js",
-    "local": "node index.js localhost",
     "dev": "nodemon",
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
**What does this implement/fix?**

_Created this PR on behalf of @mrastrom ._

Includes new `npm run local` that deploys the site with locally configured SSL certificate in express server.

Starting with the typical `npm start` or `npm run dev` will not add the SSL certificate to the express server.

**Does this close any currently open issues?**

N/A

**Any relevant logs, error output, etc?**

N/A

**Any other comments?**

N/A

**Where has this been tested?**
 - **Device:** Laptop
 - **OS:** Windows 10
 - **Browser:** Chromium
 