### PR TITLE
Fix/legal id format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Person "legalId" is now converted from format YYYY-MM-DD-XXXX to Swedish personnummer format(YYMMDD-XXXX).
+
 ## [0.1.0]
 
 ### Changed

--- a/app/public/js/main.js
+++ b/app/public/js/main.js
@@ -11,6 +11,24 @@ function onResponse(envelope, err) {
   // Get the data(CV) from the envelope
   let cv = envelope.data.data;
 
+  // Adjust the legalId format from YYYY-MM-DD-xxxx to YYMMDD-xxxx
+  // If the legalId does not match the expected format, no conversion
+  // will take place and the original value will remain unchanged.
+  try {
+    const legalIdRegex = /^\d{4}-\d{2}-\d{2}-\d{4}$/;
+    const match = cv.person.legalId.valueId.match(legalIdRegex);
+    const firstPart = match[0]
+      .split("-", 3)
+      .join("")
+      .substring(2);
+    const secondPart = match[0].split("-").pop();
+    cv.person.legalId.valueId = `${firstPart}-${secondPart}`;
+  } catch (err) {
+    console.warn(
+      "Could not convert legalId format from YYYY-MM-DD-xxxx to YYMMDD-xxxx"
+    );
+  }
+
   fetch("/cvForm", {
     method: "POST",
     headers: {


### PR DESCRIPTION
Introducing a step to convert the format received from Portability into a Swedish format personnummer.

Conversion from "YYYY-MM-DD-XXXX" to "YYMMDD-XXXX".

**This is not a breaking change.**