### PR TITLE
Fixed EJS rendering of profile employment and qualification lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed EJS rendering of profile employment and qualification lists.
+
 ## [0.1.0]
 
 ### Changed

--- a/app/views/partials/cv-form.ejs
+++ b/app/views/partials/cv-form.ejs
@@ -107,39 +107,41 @@
                             </label>
                         </div>
                         <div class="card-body">
-                            <% if (get('data.profile.employment')) { %>
-                                <% data.profile.employment.forEach((employment) => { %>
-                                    <div class="card">
-                                        <div class="card-body">
-                                            <label class="label" for="employment-title">
-                                                <h6 class="card-subtitle mb-2 text-muted">Roll</h6>
-                                            </label>
-                                            <% if (employment.title) { %>
-                                                <input name="employment-title" class="form-control" value="<%= employment.title %>" >  <br>
-                                            <% } else { %>
-                                                <input name="employment-title" class="form-control" value="" >  <br>
-                                            <% } %>
-                                            
-                                            <label class="label" for="employment-organization">
-                                                <h6 class="card-subtitle mb-2 text-muted">Organisation</h6>
-                                            </label>
-                                            <% if (employment.organization && employment.organization.name) { %>
-                                                <input name="employment-organization" class="form-control" value="<%= employment.organization.name %>" >  <br>
-                                            <% } else { %>
-                                                <input name="employment-organization" class="form-control" value="" >  <br>
-                                            <% } %>
-                                            
-                                            <label class="label" for="employment-description">
-                                                <h6 class="card-subtitle mb-2 text-muted">Rollbeskrivning</h6>
-                                            </label>
-                                            <% if (employment.description) { %>
-                                                <input name="employment-description" class="form-control" value="<%= employment.description %>" >  <br>
-                                            <% } else { %>
-                                                <input name="employment-description" class="form-control" value="" >  <br>
-                                            <% } %>
+                            <% if (get('data.profiles') && get('data.profiles').length > 0) { %>
+                                <% if (get('data.profiles')[0].employment) { %>
+                                    <% get('data.profiles')[0].employment.forEach((employment) => { %>
+                                        <div class="card">
+                                            <div class="card-body">
+                                                <label class="label" for="employment-title">
+                                                    <h6 class="card-subtitle mb-2 text-muted">Roll</h6>
+                                                </label>
+                                                <% if (employment.title) { %>
+                                                    <input name="employment-title" class="form-control" value="<%= employment.title %>" >  <br>
+                                                <% } else { %>
+                                                    <input name="employment-title" class="form-control" value="" >  <br>
+                                                <% } %>
+                                                
+                                                <label class="label" for="employment-organization">
+                                                    <h6 class="card-subtitle mb-2 text-muted">Organisation</h6>
+                                                </label>
+                                                <% if (employment.organization && employment.organization.name) { %>
+                                                    <input name="employment-organization" class="form-control" value="<%= employment.organization.name %>" >  <br>
+                                                <% } else { %>
+                                                    <input name="employment-organization" class="form-control" value="" >  <br>
+                                                <% } %>
+                                                
+                                                <label class="label" for="employment-description">
+                                                    <h6 class="card-subtitle mb-2 text-muted">Rollbeskrivning</h6>
+                                                </label>
+                                                <% if (employment.description) { %>
+                                                    <input name="employment-description" class="form-control" value="<%= employment.description %>" >  <br>
+                                                <% } else { %>
+                                                    <input name="employment-description" class="form-control" value="" >  <br>
+                                                <% } %>
+                                            </div>
                                         </div>
-                                    </div>
-                                <% }) %>
+                                    <% }) %>
+                                <% } %>
                             <% } %>
 
                             <div>
@@ -155,14 +157,16 @@
                             </label>
                         </div>
                         <div class="card-body">
-                            <% if (get('data.profile.qualifications')) { %>
-                                <% data.profile.qualifications.forEach((qualification) => { %>
-                                    <% if (qualification.competencyName) { %>
-                                        <input name="qualification-competency-name" class="form-control" value="<%= qualification.competencyName %>" >  <br>
-                                    <% } else { %>
-                                        <input name="qualification-competency-name" class="form-control" value="" >  <br>
-                                    <% } %>
-                                <% }) %>
+                            <% if (get('data.profiles') && get('data.profiles').length > 0) { %>
+                                <% if (get('data.profiles')[0].qualifications) { %>
+                                    <% get('data.profiles')[0].qualifications.forEach((qualification) => { %>
+                                        <% if (qualification.competencyName) { %>
+                                            <input name="qualification-competency-name" class="form-control" value="<%= qualification.competencyName %>" >  <br>
+                                        <% } else { %>
+                                            <input name="qualification-competency-name" class="form-control" value="" >  <br>
+                                        <% } %>
+                                    <% }) %>
+                                <% } %>
                             <% } %>
 
                             <div>


### PR DESCRIPTION
Fixes the problem where EJS failed to render the Employer or Qualification lists upon receiving envelope from AF-Portability.

**This is not a breaking change, fixes the intended behavior.**